### PR TITLE
Dont limit user to a forced version of certain build tools

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,11 +15,11 @@ requirements:
   build: 
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - autoconf {{ autoconf }}
-    - automake {{ automake }}
-    - libtool {{ libtool }}
+    - autoconf
+    - automake
+    - libtool
     - cmake {{ cmake }}
-    - make {{ make }}
+    - make
     - nasm {{ nasm }} # [x86_64]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   git_rev: {{ build_version }}
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build: 


### PR DESCRIPTION
User shouldnt be forced to have specific version of some general tools (e.g. make), if we are not truly using version-specific features. We arent requiring this consistently across many feedstocks.